### PR TITLE
Add i18n support and localized validation messages across pages

### DIFF
--- a/app/(auth)/forgot_password/page.tsx
+++ b/app/(auth)/forgot_password/page.tsx
@@ -37,7 +37,7 @@ export default function ForgotPasswordPage() {
       setSubmitted(true);
       success(t('emailSentTitle'), t('emailSentDesc'));
     } catch (error) {
-      showError('Error', t('errors.generic'));
+      showError(t('forgotPasswordTitle'), t('errors.generic'));
     }
   };
 

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -5,9 +5,8 @@ import Link from 'next/link';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useTranslations } from 'next-intl';
-import { authModel } from '@/lib/models';
 import { useRegister } from '@/lib/hooks/authHooks';
-import { RegisterForm } from '@/lib/models/Auth';
+import { createRegisterFormSchema, RegisterForm } from '@/lib/models/Auth';
 
 export default function RegisterPage() {
     const t = useTranslations("auth.register");
@@ -18,7 +17,7 @@ export default function RegisterPage() {
         handleSubmit,
         formState: { errors },
     } = useForm<RegisterForm>({
-        resolver: zodResolver(authModel.RegisterFormSchema),
+        resolver: zodResolver(createRegisterFormSchema(t)),
     }); 
 
     const onSubmit = (data: RegisterForm) => {
@@ -45,7 +44,7 @@ export default function RegisterPage() {
                 <form onSubmit={handleSubmit(onSubmit)} noValidate>
                     {error && (
                         <div className="form-error mb-4" role="alert">
-                             <strong>Error: </strong>
+                             <strong>{t('errors.generic')}: </strong>
                              {error.message || t('errors.generic')}
                         </div>
                     )}

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -10,6 +10,7 @@ import { createRegisterFormSchema, RegisterForm } from '@/lib/models/Auth';
 
 export default function RegisterPage() {
     const t = useTranslations("auth.register");
+    const tCommon = useTranslations("common");
     const { mutate: registerUser, isPending, error } = useRegister();
 
     const {
@@ -44,7 +45,7 @@ export default function RegisterPage() {
                 <form onSubmit={handleSubmit(onSubmit)} noValidate>
                     {error && (
                         <div className="form-error mb-4" role="alert">
-                             <strong>{t('errors.generic')}: </strong>
+                             <strong>{tCommon('error')}: </strong>
                              {error.message || t('errors.generic')}
                         </div>
                     )}

--- a/app/(auth)/reset_password/page.tsx
+++ b/app/(auth)/reset_password/page.tsx
@@ -3,29 +3,32 @@
 import { Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { z } from 'zod';
-
-const ResetPasswordSchema = z.object({
-    password: z.string().min(8, 'Password must be at least 8 characters.'),
-    confirmPassword: z.string(),
-}).refine((data) => data.password === data.confirmPassword, {
-    message: "Passwords don't match",
-    path: ["confirmPassword"],
-});
-
-type ResetPasswordForm = z.infer<typeof ResetPasswordSchema>;
+import { useTranslations } from 'next-intl';
 
 function ResetPasswordContent() {
     const router = useRouter();
     const searchParams = useSearchParams();
     const token = searchParams.get('token');
+    const t = useTranslations('auth.resetPassword');
+
+    const ResetPasswordSchema = z.object({
+        password: z.string().min(8, t('newPassword')),
+        confirmPassword: z.string(),
+    }).refine((data) => data.password === data.confirmPassword, {
+        message: t('confirmPassword'),
+        path: ["confirmPassword"],
+    });
+
+    type ResetPasswordForm = z.infer<typeof ResetPasswordSchema>;
 
     // Implementation similar to forgot password
-    return <div>Reset Password</div>;
+    return <div>{t('title')}</div>;
 }
 
 export default function ResetPasswordPage() {
+    const t = useTranslations('auth.resetPassword');
     return (
-        <Suspense fallback={<div>Loading...</div>}>
+        <Suspense fallback={<div>{t('submitBtn')}</div>}>
             <ResetPasswordContent />
         </Suspense>
     );

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,17 +1,19 @@
 'use client';
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 
 import { useAuth } from '@/lib/contexts/AuthContext';
 import { PermissionSchema } from '@/lib/models/Auth';
 import { useFeatures, useChangeFeature } from '@/lib/hooks/adminHooks';
 
 // A simple component for the toggle switch
-const FeatureToggle = ({ featureKey, isEnabled, onToggle, isChanging }: {
+const FeatureToggle = ({ featureKey, isEnabled, onToggle, isChanging, t }: {
     featureKey: string;
     isEnabled: boolean;
     onToggle: (key: string, enabled: boolean) => void;
     isChanging: boolean;
+    t: (key: string) => string;
 }) => (
     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '0.5rem', borderBottom: '1px solid #eee' }}>
         <span>{featureKey}</span>
@@ -27,7 +29,7 @@ const FeatureToggle = ({ featureKey, isEnabled, onToggle, isChanging }: {
                 borderRadius: '4px',
             }}
         >
-            {isChanging ? 'Updating...' : (isEnabled ? 'Enabled' : 'Disabled')}
+            {isChanging ? t('updating') : (isEnabled ? t('enabled') : t('disabled'))}
         </button>
     </div>
 );
@@ -35,6 +37,7 @@ const FeatureToggle = ({ featureKey, isEnabled, onToggle, isChanging }: {
 export default function AdminPage() {
     const { hasPermission, isLoading: isAuthLoading } = useAuth();
     const router = useRouter();
+    const t = useTranslations('admin');
 
     // 1. Protection Logic: Check for permission on component mount
     useEffect(() => {
@@ -54,7 +57,7 @@ export default function AdminPage() {
         return (
             <>
                 <main style={{ padding: '2rem' }}>
-                    <p>Verifying access...</p>
+                    <p>{t('notAuthorized')}</p>
                 </main>
             </>
         );
@@ -64,10 +67,10 @@ export default function AdminPage() {
     return (
         <>
             <main style={{ maxWidth: '800px', margin: '2rem auto', padding: '0 1rem' }}>
-                <h1>Admin Panel - Feature Flags</h1>
+                <h1>{t('featureFlags')}</h1>
 
-                {isFeaturesLoading && <p>Loading feature flags...</p>}
-                {error && <p style={{ color: 'red' }}>Error fetching features: {error.message}</p>}
+                {isFeaturesLoading && <p>{t('updating')}</p>}
+                {error && <p style={{ color: 'red' }}>{error.message}</p>}
 
                 {features && (
                     <div style={{ border: '1px solid #ddd', borderRadius: '8px' }}>
@@ -80,6 +83,7 @@ export default function AdminPage() {
                                     changeFeature({ key: featureKey, enabled: newEnabledState });
                                 }}
                                 isChanging={isChangingFeature}
+                                t={t}
                             />
                         ))}
                     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,6 @@ import ProjectCard from '@/components/projects/ProjectCard';
 
 export default function HomePage() {
   const t = useTranslations('HomePage');
-  const tProjects = useTranslations('projects');
 
   const { data, isLoading } = useProjects({ page: 0, size: 6, status: 'OPEN' });
 
@@ -31,7 +30,7 @@ export default function HomePage() {
       {!isLoading && data && data.projects.length > 0 && (
         <div className="mt-16">
           <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">
-            {tProjects('status.OPEN')} {tProjects('title')}
+            {t('openProjectsTitle')}
           </h2>
           
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/app/projects/[project_id]/page.tsx
+++ b/app/projects/[project_id]/page.tsx
@@ -1,10 +1,10 @@
-"use client";
+import { getTranslations } from 'next-intl/server';
 
-
-export default function ProjectPage() {
-
+export default async function ProjectDetailPage() {
+    const t = await getTranslations('projects');
     return (
-        <div className=""></div>
-
-    )
+        <div className="">
+            <h1>{t('title')}</h1>
+        </div>
+    );
 }

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { useState } from 'react';
+import { useTranslations } from 'next-intl';
 import { useProjects, useSearchProjects } from '@/lib/hooks/projectHooks';
 import ProjectCard from '@/components/projects/ProjectCard';
 import { ProjectStatus } from '@/lib/models';
 
 export default function ProjectsPage() {
+  const t = useTranslations('projects');
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<ProjectStatus | ''>('');
   const [currentPage, setCurrentPage] = useState(0);
@@ -42,7 +44,7 @@ export default function ProjectsPage() {
     return (
       <div className="container mx-auto px-4 py-8 text-center">
         <p className="text-red-600 dark:text-red-400">
-          Projeler yüklenirken bir hata oluştu.
+          {t('loadingError')}
         </p>
       </div>
     );
@@ -53,10 +55,10 @@ export default function ProjectsPage() {
       {/* Header */}
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">
-          Proje Pazarı
+          {t('pageTitle')}
         </h1>
         <p className="text-gray-600 dark:text-gray-400">
-          IYTE öğrencilerinin birlikte çalışabileceği projeleri keşfedin
+          {t('filterByStatus')}
         </p>
       </div>
 
@@ -64,7 +66,7 @@ export default function ProjectsPage() {
       <div className="mb-8 flex flex-col md:flex-row gap-4">
         <input
           type="text"
-          placeholder="Proje ara..."
+          placeholder={t('searchPlaceholder')}
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg
@@ -79,10 +81,10 @@ export default function ProjectsPage() {
                    bg-white dark:bg-gray-800 text-gray-900 dark:text-white
                    focus:ring-2 focus:ring-blue-500 focus:border-transparent"
         >
-          <option value="">Tüm Durumlar</option>
-          <option value="OPEN">Açık</option>
-          <option value="IN_PROGRESS">Devam Ediyor</option>
-          <option value="COMPLETED">Tamamlandı</option>
+          <option value="">{t('allStatuses')}</option>
+          <option value="OPEN">{t('status.OPEN')}</option>
+          <option value="IN_PROGRESS">{t('status.IN_PROGRESS')}</option>
+          <option value="COMPLETED">{t('status.COMPLETED')}</option>
         </select>
       </div>
 
@@ -102,11 +104,11 @@ export default function ProjectsPage() {
               disabled={currentPage === 0}
               className="px-4 py-2 bg-blue-600 text-white rounded-lg disabled:opacity-50 disabled:cursor-not-allowed hover:bg-blue-700"
             >
-              Önceki
+              {t('prevPage')}
             </button>
             
             <span className="text-gray-700 dark:text-gray-300">
-              Sayfa {currentPage + 1} / {data.totalPages}
+              {t('page', { current: currentPage + 1, total: data.totalPages })}
             </span>
             
             <button
@@ -114,14 +116,14 @@ export default function ProjectsPage() {
               disabled={currentPage >= data.totalPages - 1}
               className="px-4 py-2 bg-blue-600 text-white rounded-lg disabled:opacity-50 disabled:cursor-not-allowed hover:bg-blue-700"
             >
-              Sonraki
+              {t('nextPage')}
             </button>
           </div>
         </>
       ) : (
         <div className="text-center py-12">
           <p className="text-gray-600 dark:text-gray-400">
-            Henüz proje bulunmuyor.
+            {t('noProjectsFound')}
           </p>
         </div>
       )}

--- a/components/shared/ApiStatus.tsx
+++ b/components/shared/ApiStatus.tsx
@@ -2,10 +2,12 @@
 
 import { useQueryClient } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
+import { useTranslations } from 'next-intl';
 
 export default function ApiStatus() {
     const queryClient = useQueryClient();
     const [isOnline, setIsOnline] = useState(true);
+    const t = useTranslations('apiStatus');
 
     useEffect(() => {
         const handleOnline = () => setIsOnline(true);
@@ -27,14 +29,14 @@ export default function ApiStatus() {
 
     return (
     <div className="fixed bottom-4 right-4 bg-card border rounded-lg p-4 shadow-lg max-w-sm z-50">
-      <h3 className="font-semibold mb-2">API Status</h3>
+      <h3 className="font-semibold mb-2">{t('title')}</h3>
       <div className="space-y-1 text-sm">
         <div className="flex items-center gap-2">
           <div className={`w-2 h-2 rounded-full ${isOnline ? 'bg-green-500' : 'bg-red-500'}`} />
-          <span>{isOnline ? 'Online' : 'Offline'}</span>
+          <span>{isOnline ? t('online') : t('offline')}</span>
         </div>
-        <div>Total Queries: {queries.length}</div>
-        <div className="text-red-500">Failed Queries: {failedQueries.length}</div>
+        <div>{t('totalQueries')}: {queries.length}</div>
+        <div className="text-red-500">{t('failedQueries')}: {failedQueries.length}</div>
       </div>
     </div>
   );

--- a/lib/models/Auth.ts
+++ b/lib/models/Auth.ts
@@ -13,31 +13,31 @@ export const LogoutRequestSchema = z.object({
     agent: z.string().optional(),
 });
 
-const RegisterRequestBaseSchema = z.object({
+const createRegisterRequestBaseSchema = (t?: (key: string) => string) => z.object({
     name: z.string(),
     surname: z.string(),
     password: z.string().optional(),
     oauth_code: z.string().optional(),
-    email: z.email(),
-    phone_number: z.string().regex(/^\+\d+$/, "Phone number must start with a country code (e.g., +90) and contain no spaces."),
+    email: z.string().email(t ? t('errors.invalidEmail') : undefined),
+    phone_number: z.string().regex(/^\+\d+$/, t ? t('errors.phoneInvalid') : "Phone number must start with a country code (e.g., +90) and contain no spaces."),
     birth_date: z.string().optional(),
 });
 
-const withPasswordOrOAuthRefinements = <T extends z.ZodObject<{ password: z.ZodOptional<z.ZodString>; oauth_code: z.ZodOptional<z.ZodString> } & z.ZodRawShape>>(schema: T) =>
+const createWithPasswordOrOAuthRefinements = <T extends z.ZodObject<{ password: z.ZodOptional<z.ZodString>; oauth_code: z.ZodOptional<z.ZodString> } & z.ZodRawShape>>(schema: T, t?: (key: string) => string) =>
     schema
         .refine(data => data.password != null || data.oauth_code != null, {
-            message: "Either 'password' or 'oauth_code' must be provided.",
+            message: t ? t('errors.passwordOrOauthRequired') : "Either 'password' or 'oauth_code' must be provided.",
             path: ["password"],
         })
         .refine(data => !(data.password != null && data.oauth_code != null), {
-            message: "Cannot provide both 'password' and 'oauth_code'.",
+            message: t ? t('errors.passwordAndOauthConflict') : "Cannot provide both 'password' and 'oauth_code'.",
             path: ["oauth_code"],
         });
 
-export const RegisterRequestSchema = withPasswordOrOAuthRefinements(RegisterRequestBaseSchema);
+export const RegisterRequestSchema = createWithPasswordOrOAuthRefinements(createRegisterRequestBaseSchema());
 
 // OAuth registration doesn't have phone_number from provider
-export const OAuthRegisterRequestSchema = withPasswordOrOAuthRefinements(RegisterRequestBaseSchema.omit({ phone_number: true }));
+export const OAuthRegisterRequestSchema = createWithPasswordOrOAuthRefinements(createRegisterRequestBaseSchema().omit({ phone_number: true }));
 
 export const RefreshTokenRequestSchema = z.object({
     token: z.string(),
@@ -107,14 +107,29 @@ export const RegisterCompleteQuerySchema = z.object({
 
 
 /**
-* This schema is for form validation ONLY, not for the API call
+* This schema is for form validation ONLY, not for the API call.
+* Use createRegisterFormSchema(t) for translated error messages.
 */
 export const RegisterFormSchema = RegisterRequestSchema.safeExtend({
     passwordConfirm: z.string(),
 }).refine((data) => data.password === data.passwordConfirm, {
     message: "Passwords do not match",
-    path: ["passwordConfirm"], // Set the error on the confirmation field
+    path: ["passwordConfirm"],
 });
+
+/**
+ * Factory function that creates a RegisterFormSchema with translated error messages.
+ * @param t - Translation function from useTranslations('auth.register')
+ */
+export const createRegisterFormSchema = (t: (key: string) => string) => {
+    const base = createRegisterRequestBaseSchema(t);
+    return createWithPasswordOrOAuthRefinements(base, t)
+        .safeExtend({ passwordConfirm: z.string() })
+        .refine((data) => data.password === data.passwordConfirm, {
+            message: t('errors.passwordMismatch'),
+            path: ["passwordConfirm"],
+        });
+};
 
 
 // --- Type Exports ---

--- a/messages/en.json
+++ b/messages/en.json
@@ -2,7 +2,8 @@
   "HomePage": {
     "title": "Welcome to Project Market",
     "subtitle": "The Project Meeting Point for Students and Academicians",
-    "cta": "Explore Projects"
+    "cta": "Explore Projects",
+    "openProjectsTitle": "Open Projects"
   },
   "common": {
     "loading": "Loading...",
@@ -64,7 +65,12 @@
       "createAccount": "Create Account",
       "loginLink": "Login here",
       "errors": {
-        "generic":"An unexpected error occurred. Please try again."
+        "generic": "An unexpected error occurred. Please try again.",
+        "invalidEmail": "Please enter a valid email address",
+        "phoneInvalid": "Phone number must start with a country code (e.g., +90) and contain no spaces.",
+        "passwordOrOauthRequired": "Either password or OAuth code must be provided.",
+        "passwordAndOauthConflict": "Cannot provide both password and OAuth code.",
+        "passwordMismatch": "Passwords do not match"
       },
       "placeholders": {
         "email": "you@std.iyte.edu.tr",
@@ -80,6 +86,18 @@
         "resendBtn": "Resend Verification Email",
         "sending": "Sending..."
       }
+    },
+    "forgotPassword": {
+      "title": "Forgot Password",
+      "emailLabel": "Email Address",
+      "submitBtn": "Send Reset Link",
+      "successMessage": "Check your email for a reset link."
+    },
+    "resetPassword": {
+      "title": "Reset Password",
+      "newPassword": "New Password",
+      "confirmPassword": "Confirm Password",
+      "submitBtn": "Reset Password"
     }
   },
   "oauth": {
@@ -97,7 +115,10 @@
     "processing": {
       "title": "Authenticating",
       "description": "Please wait, your information is being processed..."
-    }
+    },
+    "completing": "Completing sign-in...",
+    "success": "Sign-in successful! Redirecting...",
+    "failed": "Sign-in failed. Please try again."
   },
   "forgotPassword": {
     "email": "Email",
@@ -118,9 +139,18 @@
   },
   "projects": {
     "title": "Projects",
+    "pageTitle": "Project Market",
     "create": "New Project",
     "search": "Search projects...",
     "filter": "Filter",
+    "searchPlaceholder": "Search projects...",
+    "filterByStatus": "Filter by status",
+    "allStatuses": "All Statuses",
+    "noProjectsFound": "No projects found.",
+    "loadingError": "Failed to load projects.",
+    "prevPage": "Previous",
+    "nextPage": "Next",
+    "page": "Page {current} of {total}",
     "status": {
       "DRAFT": "Draft",
       "OPEN": "Open",
@@ -183,6 +213,20 @@
         "generic": "An error occurred during upload"
       }
     }
+  },
+  "admin": {
+    "featureFlags": "Feature Flags",
+    "enabled": "Enabled",
+    "disabled": "Disabled",
+    "updating": "Updating...",
+    "notAuthorized": "You are not authorized to view this page."
+  },
+  "apiStatus": {
+    "title": "API Status",
+    "online": "Online",
+    "offline": "Offline",
+    "totalQueries": "Total Queries",
+    "failedQueries": "Failed Queries"
   },
   "errors": {
     "required": "This field is required",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -2,7 +2,8 @@
   "HomePage": {
     "title": "Proje Pazarı'na Hoş Geldiniz",
     "subtitle": "Öğrenciler ve Akademisyenler için Proje Buluşma Noktası",
-    "cta": "Projeleri Keşfet"
+    "cta": "Projeleri Keşfet",
+    "openProjectsTitle": "Açık Projeler"
   },
   "common": {
     "loading": "Yükleniyor...",
@@ -64,7 +65,12 @@
       "createAccount": "Hesap Oluştur",
       "loginLink": "Buradan giriş yapın",
       "errors": {
-        "generic": "Beklenmedik bir hata oluştu. Lütfen tekrar deneyin."
+        "generic": "Beklenmedik bir hata oluştu. Lütfen tekrar deneyin.",
+        "invalidEmail": "Lütfen geçerli bir e-posta adresi girin",
+        "phoneInvalid": "Telefon numarası ülke kodu ile başlamalıdır (örn. +90) ve boşluk içermemelidir.",
+        "passwordOrOauthRequired": "Şifre veya OAuth kodu sağlanmalıdır.",
+        "passwordAndOauthConflict": "Şifre ve OAuth kodu birlikte sağlanamaz.",
+        "passwordMismatch": "Şifreler eşleşmiyor"
       },
       "placeholders": {
         "email": "siz@std.iyte.edu.tr",
@@ -80,6 +86,18 @@
         "resendBtn": "Doğrulama E-postasını Tekrar Gönder",
         "sending": "Gönderiliyor..."
       }
+    },
+    "forgotPassword": {
+      "title": "Şifremi Unuttum",
+      "emailLabel": "E-posta Adresi",
+      "submitBtn": "Sıfırlama Bağlantısı Gönder",
+      "successMessage": "Sıfırlama bağlantısı için e-postanızı kontrol edin."
+    },
+    "resetPassword": {
+      "title": "Şifre Sıfırla",
+      "newPassword": "Yeni Şifre",
+      "confirmPassword": "Şifre Tekrar",
+      "submitBtn": "Şifreyi Sıfırla"
     }
   },
   "oauth": {
@@ -97,7 +115,10 @@
       "processing": {
           "title": "Kimlik Doğrulaması Yapılıyor",
           "description": "Lütfen bekleyin, bilgileriniz işleniyor..."
-      }
+      },
+      "completing": "Giriş tamamlanıyor...",
+      "success": "Giriş başarılı! Yönlendiriliyor...",
+      "failed": "Giriş başarısız. Lütfen tekrar deneyin."
   },
   "forgotPassword": {
     "email": "E-posta",
@@ -118,9 +139,18 @@
   },
   "projects": {
     "title": "Projeler",
+    "pageTitle": "Proje Pazarı",
     "create": "Yeni Proje",
     "search": "Proje ara...",
     "filter": "Filtrele",
+    "searchPlaceholder": "Proje ara...",
+    "filterByStatus": "Duruma göre filtrele",
+    "allStatuses": "Tüm Durumlar",
+    "noProjectsFound": "Proje bulunamadı.",
+    "loadingError": "Projeler yüklenemedi.",
+    "prevPage": "Önceki",
+    "nextPage": "Sonraki",
+    "page": "Sayfa {current} / {total}",
     "status": {
       "DRAFT": "Taslak",
       "OPEN": "Açık",
@@ -183,6 +213,20 @@
         "generic": "Yükleme sırasında bir hata oluştu"
       }
     }
+  },
+  "admin": {
+    "featureFlags": "Özellik Anahtarları",
+    "enabled": "Etkin",
+    "disabled": "Devre Dışı",
+    "updating": "Güncelleniyor...",
+    "notAuthorized": "Bu sayfayı görüntüleme yetkiniz yok."
+  },
+  "apiStatus": {
+    "title": "API Durumu",
+    "online": "Çevrimiçi",
+    "offline": "Çevrimdışı",
+    "totalQueries": "Toplam Sorgular",
+    "failedQueries": "Başarısız Sorgular"
   },
   "errors": {
     "required": "Bu alan zorunludur",


### PR DESCRIPTION
### ⚠️ Known Issues & Pending Fixes (Auth Validation)
While the i18n structure for Zod schemas is successfully implemented, there are a few validation behaviors that require attention in a follow-up task/PR:
* **Incomplete Error Surface:** The login and register forms currently do not display all validation errors at once. It predominantly surfaces only the email format and password mismatch errors, ignoring or hiding the others on submit.
* **Missing Student Email Restriction:** The email field currently accepts *any* valid email address. The Zod schema needs to be updated to strictly enforce student email domains (e.g., `@std.iyte.edu.tr`) for successful registration.

Superseded by #34 after dev history cleanup.