### PR TITLE
Fix frontend Docker production build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+.next
+out
+coverage
+.git
+.github
+.env
+.env.*
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+bun.lockb

--- a/lib/models/Auth.ts
+++ b/lib/models/Auth.ts
@@ -60,6 +60,7 @@ export const RegisterCompleteQuerySchema = z.object({
 * Use createRegisterFormSchema(t) for translated error messages.
 */
 export const RegisterFormSchema = RegisterRequestSchema.extend({
+    password: z.string(),
     passwordConfirm: z.string(),
 }).refine((data) => data.password === data.passwordConfirm, {
     message: "Passwords do not match",
@@ -107,4 +108,3 @@ export type LogoutRequest = z.infer<typeof LogoutRequestSchema>;
 export type RegisterRequest = z.infer<typeof RegisterRequestSchema>;
 export type RefreshTokenRequest = z.infer<typeof RefreshTokenRequestSchema>;
 export type RegisterForm = z.infer<typeof RegisterFormSchema>;
-


### PR DESCRIPTION
## Summary
- add .dockerignore so Docker builds do not copy local build artifacts or node_modules
- align RegisterFormSchema with the translated register form password field so the production Next build passes

## Validation
- docker compose -f docker-compose.yml -f docker-compose.prod.yml --profile monitoring --profile tools build app frontend
- verified frontend container response through Docker network