### PR TITLE
Docs/cli side auth model v2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Base URL of the backend API (required)
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8080

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A modern Next.js frontend application for IYTE Project Marketplace, where studen
 - **State Management**: TanStack Query (React Query) v5
 - **Form Handling**: React Hook Form + Zod
 - **HTTP Client**: Native Fetch with custom wrapper
-- **Authentication**: JWT (httpOnly cookies)
+- **Authentication**: JWT (client-readable cookies via `js-cookie`) — cookies are intentionally **not** httpOnly so the client API layer can attach them as `Authorization` headers. In production the `secure` flag is enabled; real authorization is enforced by the backend.
 - **UI Components**: shadcn/ui (to be integrated)
 
 ## ⚙️ Prerequisites

--- a/lib/auth/actions.ts
+++ b/lib/auth/actions.ts
@@ -13,7 +13,9 @@ export async function loginAction(data: authModel.LoginRequest) {
         const response = await auth.login(data);
 
         if (response.data?.accessToken && response.data?.refreshToken) {
-            // The client API layer reads these cookies to attach Authorization headers.
+            // Cookies are intentionally not httpOnly: the client-side API layer (js-cookie)
+            // must be able to read them to attach the JWT as an Authorization header on
+            // every outgoing request. The secure flag is enabled in production.
             (await cookies()).set(AUTH_TOKEN_KEY, response.data.accessToken, {
                 secure: process.env.NODE_ENV === 'production',
                 maxAge: AUTH_COOKIE_MAX_AGE,

--- a/lib/auth/permissions.ts
+++ b/lib/auth/permissions.ts
@@ -10,6 +10,8 @@ import {
     RoleSchema
 } from "../models/Auth";
 
+// UI-only guards: hasPermission, hasRole, and hasAuthLevel control what the UI renders.
+// Actual authorization is enforced by the backend on every request.
 const rolePermissions: Record<Role, Permission[]> = {
     [RoleSchema.enum.Guest]: [],
     [RoleSchema.enum.USER]: [


### PR DESCRIPTION
Closes #70 
## Summary

Documentation-only PR — no logic changes.

- Corrected `README.md`: replaced the inaccurate "JWT (httpOnly cookies)" claim with an accurate description of the client-side cookie auth model and noted that `secure` is enabled in production
- Added `.env.example` with `NEXT_PUBLIC_API_BASE_URL` so developers can clone the repo and start the dev server without reading extra documentation
- Added a comment to `lib/auth/permissions.ts` clarifying that `hasPermission`, `hasRole`, and `hasAuthLevel` are UI-only guards — real authorization is enforced by the backend
- Added a comment to `lib/auth/actions.ts` explaining why cookies are not `httpOnly` by design: the client-side API layer must read them to attach the JWT as an `Authorization` header

## Test plan
- [ ] Verify `README.md` no longer claims httpOnly cookies
- [ ] Clone the repo, copy `.env.example` to `.env.local`, run `pnpm dev` — dev server should start without any extra configuration
- [ ] Confirm no logic changes in `permissions.ts` or `actions.ts`