### PR TITLE
fix: use PUT instead of PATCH for application review endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 
 # testing
 /coverage
+/playwright-report/
+/test-results/
+/tests/e2e/.auth/
 
 # next.js
 /.next/

--- a/components/projects/ApplicationsList.tsx
+++ b/components/projects/ApplicationsList.tsx
@@ -47,14 +47,14 @@ export default function ApplicationsList({
           {application.status === ProjectApplicationStatusEnum.enum.PENDING ? (
             <div className="flex flex-wrap gap-2">
               <button
-                onClick={() => onApprove(application.applicationId ?? '')}
+                onClick={() => onApprove(application.applicationId)}
                 disabled={loading}
                 className="rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {t('approve')}
               </button>
               <button
-                onClick={() => onReject(application.applicationId ?? '')}
+                onClick={() => onReject(application.applicationId)}
                 disabled={loading}
                 className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
               >

--- a/lib/api/__tests__/project.test.ts
+++ b/lib/api/__tests__/project.test.ts
@@ -1,0 +1,51 @@
+import { updateProjectApplicationStatus } from '../project';
+import { mutator } from '../base';
+import { ProjectApplicationStatusEnum } from '@/lib/models';
+
+jest.mock('../base', () => ({
+  mutator: jest.fn(),
+}));
+
+describe('Project API functions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('updateProjectApplicationStatus', () => {
+    it('uses PUT for approving an application review', async () => {
+      const response = { code: 0, message: 'Application reviewed successfully' };
+      (mutator as jest.Mock).mockResolvedValue(response);
+
+      const result = await updateProjectApplicationStatus(
+        'application-123',
+        ProjectApplicationStatusEnum.enum.APPROVED,
+      );
+
+      expect(mutator).toHaveBeenCalledWith(
+        '/api/v1/applications/application-123/review',
+        'put',
+        expect.any(Object),
+        { arg: { status: 'APPROVED', reviewMessage: '' } },
+      );
+      expect(result).toBe(response);
+    });
+
+    it('uses PUT for rejecting an application review', async () => {
+      const response = { code: 0, message: 'Application reviewed successfully' };
+      (mutator as jest.Mock).mockResolvedValue(response);
+
+      const result = await updateProjectApplicationStatus(
+        'application-456',
+        ProjectApplicationStatusEnum.enum.REJECTED,
+      );
+
+      expect(mutator).toHaveBeenCalledWith(
+        '/api/v1/applications/application-456/review',
+        'put',
+        expect.any(Object),
+        { arg: { status: 'REJECTED', reviewMessage: '' } },
+      );
+      expect(result).toBe(response);
+    });
+  });
+});

--- a/lib/api/project.ts
+++ b/lib/api/project.ts
@@ -93,14 +93,14 @@ export async function updateProjectStatus(projectId: string, status: ProjectStat
   );
 }
 
-/** [PATCH] /api/v1/applications/{applicationId}/review - Approve or reject an application. */
+/** [PUT] /api/v1/applications/{applicationId}/review - Approve or reject an application. */
 export async function updateProjectApplicationStatus(
   applicationId: string,
   status: Extract<ProjectApplicationStatus, 'APPROVED' | 'REJECTED'>,
 ) {
   return mutator(
     `/api/v1/applications/${applicationId}/review`,
-    'patch',
+    'put',
     apiModel.BasicResponseSchema,
     { arg: { status, reviewMessage: '' } },
   );

--- a/lib/models/Project.ts
+++ b/lib/models/Project.ts
@@ -90,7 +90,7 @@ export type ProjectListResponse = z.infer<typeof MProjectListResponse>;
 
 /** Mirrors backend ApplicationDto. applicantEmail is optional — backend does not return it. */
 export const MApplicationSchema = z.object({
-  applicationId: z.string().optional(),
+  applicationId: z.string(),
   projectId: z.string().optional(),
   projectTitle: z.string().optional(),
   applicantId: z.string().optional(),


### PR DESCRIPTION
## Summary

- Fixed the HTTP method for the application review endpoint: changed `PATCH` to `PUT` to match the backend contract
- The frontend was calling `PATCH /api/v1/applications/{id}/review`, while the backend expects `PUT`, resulting in a `405 Method Not Allowed` error. This PR resolves that.

## Test plan
- [ ] Log in as a project owner and navigate to a project with a pending application
- [ ] Approve or reject the application
- [x] Verify the request returns 200 instead of 405
- [ ] Verify success UI feedback still works for both approve and reject flows

<img width="1189" height="206" alt="image" src="https://github.com/user-attachments/assets/19e62d4d-3d21-42c9-b602-4a1a19426768" />

Closes #92