### PR TITLE
fix: show admin feature flag update errors

### DIFF
--- a/lib/hooks/__tests__/adminHooks.test.ts
+++ b/lib/hooks/__tests__/adminHooks.test.ts
@@ -1,0 +1,116 @@
+import React, { type ReactNode } from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { admin } from '../../api';
+import { useChangeFeature } from '../adminHooks';
+import { useToast } from '../useToast';
+
+jest.mock('../../api', () => ({
+    admin: {
+        getFeatures: jest.fn(),
+        changeFeature: jest.fn(),
+    },
+}));
+
+jest.mock('../useToast', () => ({
+    useToast: jest.fn(),
+}));
+
+jest.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => {
+        const messages: Record<string, string> = {
+            featureUpdateErrorTitle: 'Feature flag update failed',
+            featureUpdateErrorDescription: 'Please try updating the feature flag again.',
+        };
+
+        return messages[key] ?? key;
+    },
+}));
+
+const changeFeatureMock = admin.changeFeature as jest.Mock;
+const useToastMock = useToast as jest.Mock;
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+            mutations: { retry: false },
+        },
+    });
+
+    const wrapper = ({ children }: { children: ReactNode }) =>
+        React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+    return { queryClient, wrapper };
+};
+
+describe('useChangeFeature', () => {
+    const showError = jest.fn();
+    let consoleErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        useToastMock.mockReturnValue({ error: showError });
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+    });
+
+    it('invalidates the features query when the feature flag update succeeds', async () => {
+        const { queryClient, wrapper } = createWrapper();
+        const invalidateQueriesSpy = jest.spyOn(queryClient, 'invalidateQueries');
+        changeFeatureMock.mockResolvedValueOnce({ code: 0 });
+
+        const { result } = renderHook(() => useChangeFeature(), { wrapper });
+
+        await act(async () => {
+            await result.current.mutateAsync({ key: 'Feed', enabled: true });
+        });
+
+        expect(changeFeatureMock).toHaveBeenCalledWith({ key: 'Feed', enabled: true });
+        expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ['features'] });
+        expect(showError).not.toHaveBeenCalled();
+    });
+
+    it('shows visible toast feedback and logs when the feature flag update fails', async () => {
+        const { wrapper } = createWrapper();
+        const error = new Error('Backend rejected the update');
+        changeFeatureMock.mockRejectedValueOnce(error);
+
+        const { result } = renderHook(() => useChangeFeature(), { wrapper });
+
+        await act(async () => {
+            await result.current.mutateAsync({ key: 'Feed', enabled: false }).catch(() => undefined);
+        });
+
+        await waitFor(() => {
+            expect(showError).toHaveBeenCalledWith(
+                'Feature flag update failed',
+                'Backend rejected the update',
+            );
+        });
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to change feature:', error);
+    });
+
+    it('uses a generic toast description when the mutation error has no message', async () => {
+        const { wrapper } = createWrapper();
+        changeFeatureMock.mockRejectedValueOnce('request failed');
+
+        const { result } = renderHook(() => useChangeFeature(), { wrapper });
+
+        await act(async () => {
+            await result.current.mutateAsync({ key: 'Feed', enabled: false }).catch(() => undefined);
+        });
+
+        await waitFor(() => {
+            expect(showError).toHaveBeenCalledWith(
+                'Feature flag update failed',
+                'Please try updating the feature flag again.',
+            );
+        });
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to change feature:', 'request failed');
+    });
+});

--- a/lib/hooks/adminHooks.ts
+++ b/lib/hooks/adminHooks.ts
@@ -1,7 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTranslations } from 'next-intl';
 
 import { admin } from '../api';
 import { adminModel } from '../models';
+import { useToast } from './useToast';
 
 // The key for caching and invalidating our features data
 const FEATURES_QUERY_KEY = ['features'];
@@ -24,6 +26,8 @@ export const useFeatures = () => {
  */
 export const useChangeFeature = () => {
     const queryClient = useQueryClient();
+    const t = useTranslations('admin');
+    const { error: showError } = useToast();
 
     return useMutation({
         mutationFn: (payload: adminModel.ChangeFeaturePayload) => admin.changeFeature(payload),
@@ -33,9 +37,13 @@ export const useChangeFeature = () => {
             queryClient.invalidateQueries({ queryKey: FEATURES_QUERY_KEY });
         },
         onError: (error) => {
-            // Optional: Add global error handling, like a toast notification
             console.error('Failed to change feature:', error);
+            showError(
+                t('featureUpdateErrorTitle'),
+                error instanceof Error && error.message
+                    ? error.message
+                    : t('featureUpdateErrorDescription'),
+            );
         },
     });
 };
-

--- a/messages/en.json
+++ b/messages/en.json
@@ -278,7 +278,9 @@
     "notAuthorized": "You are not authorized to view this page.",
     "verifyingAccess": "Verifying access...",
     "loadingFeatures": "Loading feature flags...",
-    "errorFetching": "Error fetching features: {message}"
+    "errorFetching": "Error fetching features: {message}",
+    "featureUpdateErrorTitle": "Feature flag update failed",
+    "featureUpdateErrorDescription": "Please try updating the feature flag again."
   },
   "apiStatus": {
     "title": "API Status",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -278,7 +278,9 @@
     "notAuthorized": "Bu sayfayı görüntüleme yetkiniz yok.",
     "verifyingAccess": "Erişim doğrulanıyor...",
     "loadingFeatures": "Özellik bayrakları yükleniyor...",
-    "errorFetching": "Özellikler alınırken hata oluştu: {message}"
+    "errorFetching": "Özellikler alınırken hata oluştu: {message}",
+    "featureUpdateErrorTitle": "Özellik bayrağı güncellenemedi",
+    "featureUpdateErrorDescription": "Lütfen özellik bayrağını tekrar güncellemeyi deneyin."
   },
   "apiStatus": {
     "title": "API Durumu",


### PR DESCRIPTION
Closes #104.

## Summary
- Show visible toast feedback when an admin feature flag update fails instead of only logging to the console.
- Keep the existing diagnostic console.error and successful query invalidation behavior unchanged.
- Add EN/TR admin copy for the feature flag update failure toast.
- Add active Jest coverage under lib/hooks/__tests__ for success invalidation, error toast feedback, and diagnostic logging.

## Validation
- npm test -- --runTestsByPath lib/hooks/__tests__/adminHooks.test.ts
- npx eslint lib/hooks/adminHooks.ts lib/hooks/__tests__/adminHooks.test.ts
- npx tsc --noEmit

## Note
- Jest still prints the existing .next/standalone/package.json haste collision warning, but the targeted suite passes.