### PR TITLE
fix: update account deletion endpoint to users/me

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useSession } from '@/lib/hooks/authHooks';
+import { useSession, useDeleteAccount } from '@/lib/hooks/authHooks';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { useTranslations } from 'next-intl';
 import ProfileEditForm from '@/components/profile/ProfileEditForm';
 import ProfilePictureUpload from '@/components/profile/ProfilePictureUpload';
+import ConfirmDialog from '@/components/shared/ConfirmDialog';
 import Link from 'next/link';
 import { useLocale } from 'next-intl';
 import { user as userApi } from '@/lib/api';
@@ -18,6 +19,8 @@ export default function ProfilePage() {
   const locale = useLocale();
   const t = useTranslations('profile');
   const [isEditing, setIsEditing] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const deleteAccountMutation = useDeleteAccount();
 
   const { data: user, isLoading: isUserLoading } = useQuery({
     queryKey: ['currentUser'],
@@ -188,7 +191,34 @@ export default function ProfilePage() {
             </Link>
           </div>
         </div>
+
+        {/* Danger Zone */}
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-8 mt-6 border border-red-200 dark:border-red-900">
+          <h2 className="text-2xl font-bold text-red-600 dark:text-red-400 mb-2">
+            {t('deleteAccount.sectionTitle')}
+          </h2>
+          <p className="text-gray-600 dark:text-gray-400 mb-4">
+            {t('deleteAccount.description')}
+          </p>
+          <button
+            onClick={() => setShowDeleteDialog(true)}
+            disabled={deleteAccountMutation.isPending}
+            className="px-4 py-2 rounded-lg text-white bg-red-600 hover:bg-red-700 disabled:opacity-50"
+          >
+            {t('deleteAccount.button')}
+          </button>
+        </div>
       </div>
+
+      <ConfirmDialog
+        open={showDeleteDialog}
+        onOpenChange={setShowDeleteDialog}
+        title={t('deleteAccount.dialogTitle')}
+        description={t('deleteAccount.dialogDescription')}
+        onConfirm={() => deleteAccountMutation.mutate()}
+        confirmText={t('deleteAccount.confirmButton')}
+        variant="destructive"
+      />
     </div>
   );
 }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -34,7 +34,7 @@ export default function ProfilePage() {
     if (!isAuthLoading && !authContext?.isAuthenticated) {
       router.push(`/${locale}/login`);
     }
-  }, [isAuthLoading, authContext, router]);
+  }, [isAuthLoading, authContext, router, locale]);
 
   if (isLoading) {
     return (
@@ -50,9 +50,6 @@ export default function ProfilePage() {
   if (!authContext?.isAuthenticated || !user) {
     return null;
   }
-
-  const displayName = (user.fullName ?? `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim()) || user.email;
-  const avatarInitial = (user.firstName ?? user.email ?? '').charAt(0).toUpperCase();
 
   return (
     <div className="container mx-auto px-4 py-8">

--- a/lib/api/__tests__/user.test.ts
+++ b/lib/api/__tests__/user.test.ts
@@ -1,0 +1,30 @@
+import { deleteUser } from '../user';
+import { mutator } from '../base';
+
+jest.mock('../base', () => ({
+  mutator: jest.fn(),
+  fetcher: jest.fn(),
+}));
+
+describe('User API functions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('deleteUser', () => {
+    it('deletes the authenticated user without requiring a user id', async () => {
+      const response = { code: 0, message: 'User deleted successfully' };
+      (mutator as jest.Mock).mockResolvedValue(response);
+
+      const result = await deleteUser();
+
+      expect(mutator).toHaveBeenCalledWith(
+        '/api/v1/users/me',
+        'delete',
+        expect.any(Object),
+        { arg: {} },
+      );
+      expect(result).toBe(response);
+    });
+  });
+});

--- a/lib/api/user.ts
+++ b/lib/api/user.ts
@@ -56,9 +56,9 @@ export const createUser = (payload: userModel.MUser) =>
 export const updateUserLanguage = (language: 'tr' | 'en') =>
     mutator(`/api/v1/users/me/language`, 'put', apiModel.BasicResponseSchema, { arg: { language } });
 
-/** [DELETE] /api/v1/users/:id - Deletes the user. (Durumu meçhul) */
-export const deleteUser = (id?: number) =>
-    mutator(`/api/v1/users/${id ?? 'me'}`, 'delete', apiModel.BasicResponseSchema, { arg: {} });
+/** [DELETE] /api/v1/users/me - Deletes the authenticated user. */
+export const deleteUser = () =>
+    mutator('/api/v1/users/me', 'delete', apiModel.BasicResponseSchema, { arg: {} });
 
 /** [POST] /api/v1/users/verify/phone - Verifies the new phone number. (Durumu meçhul) */
 export const verifyPhone = (code: string) =>

--- a/lib/hooks/__tests__/authHooks.test.ts
+++ b/lib/hooks/__tests__/authHooks.test.ts
@@ -1,0 +1,107 @@
+import React, { type ReactNode } from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+import { user } from '../../api';
+import { logoutAction } from '../../auth/actions';
+import { useDeleteAccount } from '../authHooks';
+import { useApiError } from '../useApiError';
+
+jest.mock('../../api', () => ({
+    auth: {},
+    user: {
+        getCurrentUser: jest.fn(),
+        deleteUser: jest.fn(),
+    },
+}));
+
+jest.mock('../../auth/actions', () => ({
+    loginAction: jest.fn(),
+    logoutAction: jest.fn(),
+}));
+
+jest.mock('../../auth/permissions', () => ({
+    getAuthContextFromUser: jest.fn(),
+}));
+
+jest.mock('../useApiError', () => ({
+    useApiError: jest.fn(),
+}));
+
+jest.mock('next/navigation', () => ({
+    useRouter: jest.fn(),
+}));
+
+jest.mock('next-intl', () => ({
+    useLocale: jest.fn(() => 'tr'),
+}));
+
+const deleteUserMock = user.deleteUser as jest.Mock;
+const logoutActionMock = logoutAction as jest.Mock;
+const useApiErrorMock = useApiError as jest.Mock;
+const useRouterMock = useRouter as jest.Mock;
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+            mutations: { retry: false },
+        },
+    });
+
+    const wrapper = ({ children }: { children: ReactNode }) =>
+        React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+    return { queryClient, wrapper };
+};
+
+describe('useDeleteAccount', () => {
+    const handleError = jest.fn();
+    const push = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        useApiErrorMock.mockReturnValue({ handleError });
+        useRouterMock.mockReturnValue({ push });
+        logoutActionMock.mockResolvedValue(undefined);
+    });
+
+    it('clears cached auth state, clears auth cookies, and redirects to login on success', async () => {
+        const { queryClient, wrapper } = createWrapper();
+        const clearSpy = jest.spyOn(queryClient, 'clear');
+        deleteUserMock.mockResolvedValueOnce({ code: 0, message: 'User deleted successfully' });
+
+        const { result } = renderHook(() => useDeleteAccount(), { wrapper });
+
+        await act(async () => {
+            await result.current.mutateAsync();
+        });
+
+        expect(deleteUserMock).toHaveBeenCalled();
+        expect(clearSpy).toHaveBeenCalled();
+        expect(logoutActionMock).toHaveBeenCalled();
+        expect(push).toHaveBeenCalledWith('/tr/login');
+        expect(handleError).not.toHaveBeenCalled();
+    });
+
+    it('shows the error UI and preserves auth state when deletion fails', async () => {
+        const { queryClient, wrapper } = createWrapper();
+        const clearSpy = jest.spyOn(queryClient, 'clear');
+        const error = new Error('Account deletion failed');
+        deleteUserMock.mockRejectedValueOnce(error);
+
+        const { result } = renderHook(() => useDeleteAccount(), { wrapper });
+
+        await act(async () => {
+            await result.current.mutateAsync().catch(() => undefined);
+        });
+
+        await waitFor(() => {
+            expect(handleError).toHaveBeenCalledWith(error);
+        });
+        expect(clearSpy).not.toHaveBeenCalled();
+        expect(logoutActionMock).not.toHaveBeenCalled();
+        expect(push).not.toHaveBeenCalled();
+    });
+});

--- a/lib/hooks/authHooks.ts
+++ b/lib/hooks/authHooks.ts
@@ -9,6 +9,7 @@ import { loginAction, logoutAction } from '../auth/actions';
 import { userModel, apiModel, authModel } from "../models";
 import { auth, user } from '../api';
 import { ApiError } from '../api/base';
+import { useApiError } from './useApiError';
 
 
 // The query key for the main user session from our previous discussion
@@ -86,6 +87,29 @@ export const useLogout = () => {
         },
         onError: (error: Error) => {
             console.error('Logout failed:', error.message);
+        },
+    });
+};
+
+/**
+ * Hook to delete the authenticated user's account.
+ * On success, reuses the logout mutation to clear auth cookies, drop the
+ * cached session/user data, and perform a locale-aware redirect to login.
+ */
+export const useDeleteAccount = () => {
+    const queryClient = useQueryClient();
+    const logout = useLogout();
+    const { handleError } = useApiError();
+
+    return useMutation({
+        mutationFn: user.deleteUser,
+        onSuccess: async () => {
+            queryClient.clear();
+            await logout.mutateAsync();
+        },
+        onError: (error) => {
+            console.error('Account deletion failed:', error);
+            handleError(error);
         },
     });
 };

--- a/messages/en.json
+++ b/messages/en.json
@@ -225,6 +225,14 @@
     "contact": "Contact Information",
     "social": "Social Links",
     "language": "Language Preference",
+    "deleteAccount": {
+      "sectionTitle": "Delete Account",
+      "description": "Deleting your account permanently removes all your data. This action cannot be undone.",
+      "button": "Delete My Account",
+      "dialogTitle": "Are you sure you want to delete your account?",
+      "dialogDescription": "This action cannot be undone. Your account and all data associated with it will be permanently deleted.",
+      "confirmButton": "Delete Account"
+    },
     "edit": {
       "name": "First Name",
       "surname": "Last Name",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -225,6 +225,14 @@
     "contact": "İletişim Bilgileri",
     "social": "Sosyal Bağlantılar",
     "language": "Dil Tercihi",
+    "deleteAccount": {
+      "sectionTitle": "Hesabı Sil",
+      "description": "Hesabınızı sildiğinizde tüm verileriniz kalıcı olarak silinir. Bu işlem geri alınamaz.",
+      "button": "Hesabımı Sil",
+      "dialogTitle": "Hesabınızı silmek istediğinize emin misiniz?",
+      "dialogDescription": "Bu işlem geri alınamaz. Hesabınız ve hesabınızla ilişkili tüm veriler kalıcı olarak silinecektir.",
+      "confirmButton": "Hesabı Sil"
+    },
     "edit": {
       "name": "İsim",
       "surname": "Soyisim",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "@types/node": "^20",
         "@types/react": "^19.2.9",
         "@types/react-dom": "^19",
-        "baseline-browser-mapping": "^2.10.33",
         "dotenv": "^17.4.2",
         "eslint": "^9",
         "eslint-config-next": "16.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@types/node": "^20",
         "@types/react": "^19.2.9",
         "@types/react-dom": "^19",
+        "baseline-browser-mapping": "^2.10.33",
         "dotenv": "^17.4.2",
         "eslint": "^9",
         "eslint-config-next": "16.0.8",
@@ -4918,9 +4919,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.12",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
-      "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
+      "version": "2.10.33",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
+      "integrity": "sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/node": "^20",
     "@types/react": "^19.2.9",
     "@types/react-dom": "^19",
+    "baseline-browser-mapping": "^2.10.33",
     "dotenv": "^17.4.2",
     "eslint": "^9",
     "eslint-config-next": "16.0.8",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@types/node": "^20",
     "@types/react": "^19.2.9",
     "@types/react-dom": "^19",
-    "baseline-browser-mapping": "^2.10.33",
     "dotenv": "^17.4.2",
     "eslint": "^9",
     "eslint-config-next": "16.0.8",


### PR DESCRIPTION
## Summary

- Updated account deletion API call to use `DELETE /api/v1/users/me`
- Removed user id requirement from `deleteUser()`
- Added API test coverage for the account deletion endpoint

## Testing

- `npm test -- --runTestsByPath lib/api/__tests__/user.test.ts`
- Verified via Swagger that `DELETE /api/v1/users/me` returns `200`
- Confirmed the deactivated account can no longer log in afterwards
Closes #93 
<img width="1432" height="975" alt="image" src="https://github.com/user-attachments/assets/d36d5565-2f6f-4e33-a02b-10ea33ea1b8e" />
