### PR TITLE
fix(auth): persist language preference and require access token

### DIFF
--- a/components/shared/Header.tsx
+++ b/components/shared/Header.tsx
@@ -59,7 +59,10 @@ export default function Header() {
 
         {/* Right side */}
         <div className="flex items-center gap-3">
-          <LanguageSwitcher />
+          <LanguageSwitcher
+            disabled={isLoading}
+            persistPreference={session?.isAuthenticated === true}
+          />
 
           {isLoading ? (
             <div className="h-8 w-8 rounded-full bg-muted animate-pulse" />

--- a/components/shared/LanguageSwitcher.tsx
+++ b/components/shared/LanguageSwitcher.tsx
@@ -4,18 +4,45 @@ import { useLocale } from 'next-intl';
 import { locales } from '@/i18n-config';
 import type { Locale } from '@/i18n-config';
 import { setLocale } from '@/lib/actions/locale';
+import { updateUserLanguage } from '@/lib/api/user';
+import { useApiError } from '@/lib/hooks/useApiError';
+import { useQueryClient } from '@tanstack/react-query';
 import { useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 
-export default function LanguageSwitcher() {
+interface LanguageSwitcherProps {
+  disabled?: boolean;
+  persistPreference?: boolean;
+}
+
+export default function LanguageSwitcher({
+  disabled = false,
+  persistPreference = false,
+}: LanguageSwitcherProps) {
   const locale = useLocale();
   const router = useRouter();
+  const queryClient = useQueryClient();
+  const { handleError } = useApiError();
   const [isPending, startTransition] = useTransition();
 
   const switchLocale = (newLocale: Locale) => {
     startTransition(async () => {
-      await setLocale(newLocale);
-      router.refresh();
+      try {
+        if (persistPreference) {
+          await updateUserLanguage(newLocale);
+        }
+
+        await setLocale(newLocale);
+
+        if (persistPreference) {
+          void queryClient.invalidateQueries({ queryKey: ['session'] });
+          void queryClient.invalidateQueries({ queryKey: ['currentUser'] });
+        }
+
+        router.refresh();
+      } catch (error) {
+        handleError(error);
+      }
     });
   };
 
@@ -25,7 +52,7 @@ export default function LanguageSwitcher() {
         <button
           key={loc}
           onClick={() => switchLocale(loc)}
-          disabled={isPending || locale === loc}
+          disabled={disabled || isPending || locale === loc}
           className={`px-3 py-1 rounded transition-colors ${
             locale === loc 
               ? 'bg-[var(--color-btn-primary)] text-[var(--color-text-inverse)]' 

--- a/components/shared/__tests__/LanguageSwitcher.test.tsx
+++ b/components/shared/__tests__/LanguageSwitcher.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useLocale } from 'next-intl';
+import { useRouter } from 'next/navigation';
+
+import LanguageSwitcher from '../LanguageSwitcher';
+import { setLocale } from '@/lib/actions/locale';
+import { updateUserLanguage } from '@/lib/api/user';
+import { useApiError } from '@/lib/hooks/useApiError';
+
+jest.mock('next-intl', () => ({
+  useLocale: jest.fn(),
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('@/lib/actions/locale', () => ({
+  setLocale: jest.fn(),
+}));
+
+jest.mock('@/lib/api/user', () => ({
+  updateUserLanguage: jest.fn(),
+}));
+
+jest.mock('@/lib/hooks/useApiError', () => ({
+  useApiError: jest.fn(),
+}));
+
+const useLocaleMock = useLocale as jest.Mock;
+const useRouterMock = useRouter as jest.Mock;
+const setLocaleMock = setLocale as jest.Mock;
+const updateUserLanguageMock = updateUserLanguage as jest.Mock;
+const useApiErrorMock = useApiError as jest.Mock;
+
+describe('LanguageSwitcher', () => {
+  const refresh = jest.fn();
+  const handleError = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useLocaleMock.mockReturnValue('tr');
+    useRouterMock.mockReturnValue({ refresh });
+    useApiErrorMock.mockReturnValue({ handleError });
+    setLocaleMock.mockResolvedValue(undefined);
+    updateUserLanguageMock.mockResolvedValue({ code: 0 });
+  });
+
+  const renderSwitcher = ({
+    disabled = false,
+    persistPreference = false,
+  }: {
+    disabled?: boolean;
+    persistPreference?: boolean;
+  } = {}) => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const invalidateQueries = jest.spyOn(queryClient, 'invalidateQueries');
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <LanguageSwitcher disabled={disabled} persistPreference={persistPreference} />
+      </QueryClientProvider>,
+    );
+
+    return { invalidateQueries };
+  };
+
+  it('changes only the local locale for a guest', async () => {
+    const { invalidateQueries } = renderSwitcher();
+
+    fireEvent.click(screen.getByRole('button', { name: 'EN' }));
+
+    await waitFor(() => {
+      expect(setLocaleMock).toHaveBeenCalledWith('en');
+      expect(refresh).toHaveBeenCalled();
+    });
+    expect(updateUserLanguageMock).not.toHaveBeenCalled();
+    expect(invalidateQueries).not.toHaveBeenCalled();
+  });
+
+  it('persists an authenticated preference before changing the local locale', async () => {
+    const { invalidateQueries } = renderSwitcher({ persistPreference: true });
+
+    fireEvent.click(screen.getByRole('button', { name: 'EN' }));
+
+    await waitFor(() => {
+      expect(updateUserLanguageMock).toHaveBeenCalledWith('en');
+      expect(setLocaleMock).toHaveBeenCalledWith('en');
+      expect(refresh).toHaveBeenCalled();
+    });
+
+    expect(updateUserLanguageMock.mock.invocationCallOrder[0])
+      .toBeLessThan(setLocaleMock.mock.invocationCallOrder[0]);
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['session'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['currentUser'] });
+  });
+
+  it('keeps the current locale and surfaces an authenticated persistence failure', async () => {
+    const error = new Error('Could not persist language');
+    updateUserLanguageMock.mockRejectedValueOnce(error);
+    renderSwitcher({ persistPreference: true });
+
+    fireEvent.click(screen.getByRole('button', { name: 'EN' }));
+
+    await waitFor(() => {
+      expect(handleError).toHaveBeenCalledWith(error);
+    });
+    expect(setLocaleMock).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('does not switch while authentication state is loading', () => {
+    renderSwitcher({ disabled: true });
+
+    expect(screen.getByRole('button', { name: 'EN' })).toBeDisabled();
+  });
+});

--- a/lib/api/__tests__/user.test.ts
+++ b/lib/api/__tests__/user.test.ts
@@ -1,4 +1,4 @@
-import { deleteUser } from '../user';
+import { deleteUser, updateUserLanguage } from '../user';
 import { mutator } from '../base';
 
 jest.mock('../base', () => ({
@@ -23,6 +23,23 @@ describe('User API functions', () => {
         'delete',
         expect.any(Object),
         { arg: {} },
+      );
+      expect(result).toBe(response);
+    });
+  });
+
+  describe('updateUserLanguage', () => {
+    it('updates preferredLanguage through the profile endpoint', async () => {
+      const response = { code: 0, message: 'Profile updated successfully' };
+      (mutator as jest.Mock).mockResolvedValue(response);
+
+      const result = await updateUserLanguage('en');
+
+      expect(mutator).toHaveBeenCalledWith(
+        '/api/v1/users/me',
+        'put',
+        expect.any(Object),
+        { arg: { preferredLanguage: 'en' } },
       );
       expect(result).toBe(response);
     });

--- a/lib/api/user.ts
+++ b/lib/api/user.ts
@@ -31,6 +31,10 @@ export const listUsers = (params: { page?: number, pageSize?: number, sby?: stri
 export const updateUser = (payload: userModel.UpdateUserProfileCommand) =>
     mutator('/api/v1/users/me', 'put', apiModel.BasicResponseSchema, { arg: payload });
 
+/** Updates the authenticated user's persisted language preference. */
+export const updateUserLanguage = (preferredLanguage: 'tr' | 'en') =>
+    updateUser({ preferredLanguage });
+
 // Response schema for GET /api/v1/users/me/applications
 const PagedApplicationsResponseSchema = z.object({
     applications: z.array(MApplicationSchema),
@@ -51,10 +55,6 @@ export const getMyApplications = () =>
 /** [POST] /api/v1/users - Creates a new user manually. (TABLODA 'NO SUCH ENDPOINT' DİYOR) */
 export const createUser = (payload: userModel.MUser) =>
     mutator('/api/v1/users', 'post', apiModel.DataResponseSchema(z.number()), { arg: payload });
-
-/** [PUT] /api/v1/users/me/language - Updates the user's language. (TABLODA 'NO SUCH ENDPOINT' DİYOR) */
-export const updateUserLanguage = (language: 'tr' | 'en') =>
-    mutator(`/api/v1/users/me/language`, 'put', apiModel.BasicResponseSchema, { arg: { language } });
 
 /** [DELETE] /api/v1/users/me - Deletes the authenticated user. */
 export const deleteUser = () =>

--- a/lib/models/Api.ts
+++ b/lib/models/Api.ts
@@ -104,7 +104,7 @@ export const TokenResponseSchema = DataResponseSchema(
         userId: z.string().optional(),
         email: z.string().optional(),
         role: z.string().optional(),
-        accessToken: z.string().optional(),
+        accessToken: z.string(),
         refreshToken: z.string().optional(),
     }),
 );
@@ -124,4 +124,5 @@ export type ResponseCode = z.infer<typeof ResponseCodeSchema>;
 export type ErrorCode = z.infer<typeof ErrorCodeSchema>;
 export type BasicResponse = z.infer<typeof BasicResponseSchema>;
 export type LoginResult = z.infer<typeof LoginResultSchema>;
+export type TokenResponse = z.infer<typeof TokenResponseSchema>;
 export type RefreshResult = z.infer<typeof RefreshResultSchema>;

--- a/lib/models/User.ts
+++ b/lib/models/User.ts
@@ -20,18 +20,19 @@ export const MUserSchema = z.object({
     projectsCreated: z.number().optional(),
     applicationsSubmitted: z.number().optional(),
     projects: z.array(MProject).optional(),
+    preferredLanguage: z.enum(['tr', 'en']).optional(),
     // Not returned by profile endpoint — populated from token if needed
     role: z.string().optional(),
 });
 
 export const UpdateUserProfileCommandSchema = z.object({
-    userId: z.string(),
+    userId: z.string().optional(),
     firstName: z.string().optional(),
     lastName: z.string().optional(),
     description: z.string().optional(),
     linkedinUrl: z.string().optional(),
     githubUrl: z.string().optional(),
-    preferredLanguage: z.string().optional(),
+    preferredLanguage: z.enum(['tr', 'en']).optional(),
 });
 
 export type MUser = z.infer<typeof MUserSchema>;

--- a/lib/models/__tests__/Api.test.ts
+++ b/lib/models/__tests__/Api.test.ts
@@ -1,0 +1,32 @@
+import { TokenResponseSchema } from '../Api';
+
+describe('TokenResponseSchema', () => {
+  const validResponse = {
+    code: 0,
+    data: {
+      userId: 'user-123',
+      email: 'user@std.iyte.edu.tr',
+      role: 'USER',
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+    },
+  };
+
+  it('accepts an authentication response containing an access token', () => {
+    expect(TokenResponseSchema.parse(validResponse)).toEqual(validResponse);
+  });
+
+  it('rejects an authentication response without an access token', () => {
+    const responseWithoutAccessToken = {
+      ...validResponse,
+      data: {
+        userId: validResponse.data.userId,
+        email: validResponse.data.email,
+        role: validResponse.data.role,
+        refreshToken: validResponse.data.refreshToken,
+      },
+    };
+
+    expect(TokenResponseSchema.safeParse(responseWithoutAccessToken).success).toBe(false);
+  });
+});

--- a/lib/models/__tests__/User.test.ts
+++ b/lib/models/__tests__/User.test.ts
@@ -1,0 +1,22 @@
+import { MUserSchema, UpdateUserProfileCommandSchema } from '../User';
+
+describe('user language schemas', () => {
+  it('retains the preferred language returned by the profile endpoint', () => {
+    const profile = MUserSchema.parse({
+      id: 'user-123',
+      email: 'user@std.iyte.edu.tr',
+      preferredLanguage: 'en',
+    });
+
+    expect(profile.preferredLanguage).toBe('en');
+  });
+
+  it('accepts only supported preferred languages in profile updates', () => {
+    expect(
+      UpdateUserProfileCommandSchema.safeParse({ preferredLanguage: 'tr' }).success,
+    ).toBe(true);
+    expect(
+      UpdateUserProfileCommandSchema.safeParse({ preferredLanguage: 'de' }).success,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- persist authenticated language changes through `PUT /api/v1/users/me`
- keep guest language changes local to the locale cookie
- retain `preferredLanguage` in the user profile schema and restrict it to supported locales
- require `accessToken` in `TokenResponseSchema`
- keep the current locale unchanged and show the existing API error toast when persistence fails

## Root cause

The frontend retained a helper for a nonexistent `/api/v1/users/me/language` endpoint, while the visible language switcher only updated the locale cookie. The authentication response schema also treated the backend-required access token as optional, masking malformed integration responses.

## Impact

Authenticated language changes are now persisted before the UI switches, cached profile/session data is invalidated after success, and guests retain the existing local-only behavior. Login and refresh responses without an access token now fail Zod validation through the existing error paths.

## Validation

- `npx jest lib/api/__tests__/user.test.ts lib/models/__tests__/Api.test.ts lib/models/__tests__/User.test.ts components/shared/__tests__/LanguageSwitcher.test.tsx --runInBand` (10 tests passed)
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`

The repository-wide `npm test` baseline remains red because Jest collects Playwright specs and unrelated auth tests assert stale paths; those pre-existing failures are outside this PR.

Closes #95
Closes #100
