### PR TITLE
refactor(projects): align search response contract

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -82,10 +82,10 @@ export default function ProjectsPage() {
             <div key={i} className="bg-gray-200 dark:bg-gray-700 rounded-lg h-64 animate-pulse" />
           ))}
         </div>
-      ) : data && (data.projects?.length ?? 0) > 0 ? (
+      ) : data && data.projects.length > 0 ? (
         <>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-            {data.projects?.map((project) => (
+            {data.projects.map((project) => (
               <ProjectCard key={project.id} project={project} />
             ))}
           </div>
@@ -98,11 +98,11 @@ export default function ProjectsPage() {
               {t('prevPage')}
             </button>
             <span className="text-gray-700 dark:text-gray-300">
-              {t('page', { current: currentPage + 1, total: data.totalPages ?? 1 })}
+              {t('page', { current: currentPage + 1, total: data.totalPages })}
             </span>
             <button
-              onClick={() => setCurrentPage((p) => Math.min((data.totalPages ?? 1) - 1, p + 1))}
-              disabled={currentPage >= (data.totalPages ?? 1) - 1}
+              onClick={() => setCurrentPage((p) => Math.min(data.totalPages - 1, p + 1))}
+              disabled={currentPage >= data.totalPages - 1}
               className="px-4 py-2 bg-blue-600 text-white rounded-lg disabled:opacity-50 disabled:cursor-not-allowed hover:bg-blue-700"
             >
               {t('nextPage')}

--- a/lib/api/__tests__/project.test.ts
+++ b/lib/api/__tests__/project.test.ts
@@ -1,8 +1,9 @@
-import { updateProjectApplicationStatus } from '../project';
-import { mutator } from '../base';
-import { ProjectApplicationStatusEnum } from '@/lib/models';
+import { searchProjects, updateProjectApplicationStatus } from '../project';
+import { fetcher, mutator } from '../base';
+import { MProjectListResponse, ProjectApplicationStatusEnum } from '@/lib/models';
 
 jest.mock('../base', () => ({
+  fetcher: jest.fn(),
   mutator: jest.fn(),
 }));
 
@@ -46,6 +47,38 @@ describe('Project API functions', () => {
         { arg: { status: 'REJECTED', reviewMessage: '' } },
       );
       expect(result).toBe(response);
+    });
+  });
+
+  describe('searchProjects', () => {
+    it('returns the backend-provided project page without fabricating pagination', async () => {
+      const response = {
+        projects: [
+          {
+            id: 'project-123',
+            ownerId: 'owner-123',
+            ownerName: 'Ada Lovelace',
+            title: 'Searchable Project',
+            applicationCount: 4,
+            status: 'OPEN',
+          },
+        ],
+        currentPage: 2,
+        totalPages: 5,
+        totalElements: 49,
+      };
+      (fetcher as jest.Mock).mockResolvedValue(response);
+
+      const result = await searchProjects('machine learning', { page: 2, size: 12 });
+
+      expect(fetcher).toHaveBeenCalledWith(
+        '/api/v1/search/projects?q=machine+learning&page=2&size=12',
+        MProjectListResponse,
+      );
+      expect(result).toBe(response);
+      expect(result.currentPage).toBe(2);
+      expect(result.totalPages).toBe(5);
+      expect(result.totalElements).toBe(49);
     });
   });
 });

--- a/lib/api/project.ts
+++ b/lib/api/project.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { fetcher, mutator } from './base';
-import { MProject, MProjectListResponse, MApplicationSchema, MSearchProjectResult, mapSearchResultToProject } from '@/lib/models';
+import { MProject, MProjectListResponse, MApplicationSchema } from '@/lib/models';
 import { apiModel } from '@/lib/models';
 import type { Project, ProjectListResponse, ProjectApplicationStatus, ProjectStatus } from '@/lib/models';
 
@@ -40,19 +40,10 @@ export async function searchProjects(keyword: string, params?: GetProjectsParams
   if (params?.page !== undefined) queryParams.append('page', params.page.toString());
   if (params?.size !== undefined) queryParams.append('size', params.size.toString());
 
-  // Search endpoint returns a flat array with a different project shape than the list endpoint.
-  // We map it to the standard ProjectListResponse so callers don't need to know the difference.
-  const results = await fetcher(
+  return fetcher(
     `/api/v1/search/projects?${queryParams.toString()}`,
-    z.array(MSearchProjectResult),
+    MProjectListResponse,
   );
-
-  return {
-    projects: results.map(mapSearchResultToProject),
-    currentPage: params?.page ?? 0,
-    totalPages: 1,
-    totalElements: results.length,
-  };
 }
 
 /** [POST] /api/v1/projects/{projectId}/applications - Apply to a project. No request body needed. */

--- a/lib/models/Project.ts
+++ b/lib/models/Project.ts
@@ -38,52 +38,12 @@ export const ProjectApplicationStatusEnum = z.enum([
 
 export type ProjectApplicationStatus = z.infer<typeof ProjectApplicationStatusEnum>;
 
-/**
- * Search endpoint (/api/v1/search/projects) returns a flat array with a different shape
- * than the regular projects endpoint. owner is nested, field names differ.
- */
-export const MSearchProjectResult = z.object({
-  id: z.string().nullish(),
-  title: z.string().nullish(),
-  description: z.string().nullish(),
-  summary: z.string().nullish(),
-  status: ProjectStatusEnum.optional(),
-  owner: z.object({
-    id: z.string().nullish(),
-    name: z.string().nullish(),
-    email: z.string().nullish(),
-  }).nullish(),
-  tags: z.array(z.string()).nullish(),
-  createdAt: z.string().nullish(),
-  updatedAt: z.string().nullish(),
-  applicationsCount: z.number().nullish(),
-});
-
-export type SearchProjectResult = z.infer<typeof MSearchProjectResult>;
-
-/** Maps the search endpoint's project shape to the standard MProject shape */
-export function mapSearchResultToProject(r: SearchProjectResult): z.infer<typeof MProject> {
-  return {
-    id: r.id ?? undefined,
-    ownerId: r.owner?.id ?? undefined,
-    ownerName: r.owner?.name ?? undefined,
-    ownerEmail: r.owner?.email ?? undefined,
-    title: r.title ?? undefined,
-    description: r.description ?? undefined,
-    summary: r.summary ?? undefined,
-    applicationCount: r.applicationsCount ?? undefined,
-    status: r.status,
-    requiredSkills: r.tags ?? undefined,
-    createdAt: r.createdAt ?? undefined,
-  };
-}
-
 /** Mirrors backend PagedProjectsResult */
 export const MProjectListResponse = z.object({
-  projects: z.array(MProject).optional(),
-  currentPage: z.number().optional(),
-  totalPages: z.number().optional(),
-  totalElements: z.number().optional(),
+  projects: z.array(MProject),
+  currentPage: z.number(),
+  totalPages: z.number(),
+  totalElements: z.number(),
 });
 
 export type ProjectListResponse = z.infer<typeof MProjectListResponse>;

--- a/lib/models/__tests__/Project.test.ts
+++ b/lib/models/__tests__/Project.test.ts
@@ -1,0 +1,48 @@
+import { MProjectListResponse } from '../Project';
+
+describe('MProjectListResponse', () => {
+  const projectPage = {
+    projects: [
+      {
+        id: 'project-123',
+        ownerId: 'owner-123',
+        ownerName: 'Ada Lovelace',
+        ownerEmail: 'ada@std.iyte.edu.tr',
+        title: 'Searchable Project',
+        description: 'A project returned by search.',
+        applicationCount: 7,
+        status: 'OPEN',
+        requiredSkills: ['TypeScript'],
+      },
+    ],
+    currentPage: 1,
+    totalPages: 3,
+    totalElements: 25,
+  };
+
+  it('parses flat owner fields, applicationCount, and pagination metadata', () => {
+    const parsed = MProjectListResponse.parse(projectPage);
+
+    expect(parsed.projects[0]).toMatchObject({
+      ownerId: 'owner-123',
+      ownerName: 'Ada Lovelace',
+      applicationCount: 7,
+    });
+    expect(parsed).toMatchObject({
+      currentPage: 1,
+      totalPages: 3,
+      totalElements: 25,
+    });
+  });
+
+  it('rejects the legacy unpaged search array', () => {
+    expect(MProjectListResponse.safeParse(projectPage.projects).success).toBe(false);
+  });
+
+  it('requires backend pagination metadata', () => {
+    const pageWithoutTotalPages: Partial<typeof projectPage> = { ...projectPage };
+    delete pageWithoutTotalPages.totalPages;
+
+    expect(MProjectListResponse.safeParse(pageWithoutTotalPages).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- parse search responses with the shared paged-project schema
- remove the legacy nested-owner search schema and normalization mapper
- consume flat `ownerId` / `ownerName` and singular `applicationCount`
- require backend-provided `projects`, `currentPage`, `totalPages`, and `totalElements`
- remove the frontend's fabricated `totalPages: 1` pagination

## Root cause

The frontend still modeled the pre-#133 search response as an unpaged array with nested owner data and `applicationsCount`. It then fabricated pagination locally, preventing users from navigating real search result pages.

## Impact

Search and regular project listing now share the backend's paged response contract. The projects page renders and navigates using the backend's real pagination values. Existing `id` and `title` fields remain unchanged because frontend issue #96 is intentionally waiting on backend issue #132.

## Validation

- `npx jest lib/api/__tests__/project.test.ts lib/models/__tests__/Project.test.ts --runInBand` (6 tests passed)
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`

The repository-wide `npm test` baseline remains red because Jest collects Playwright specs and unrelated auth tests assert stale paths; those pre-existing failures are outside this PR.

Closes #97
