### PR TITLE
refactor: remove auth/status dead code and adopt hook pattern in ProfileEditForm

### DIFF
--- a/components/profile/ProfileEditForm.tsx
+++ b/components/profile/ProfileEditForm.tsx
@@ -3,9 +3,7 @@
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { useState } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
-import { user as userApi } from '@/lib/api';
+import { useUpdateProfile } from '@/lib/hooks/userHooks';
 import type { userModel } from '@/lib/models';
 import { useTranslations } from 'next-intl';
 
@@ -24,9 +22,7 @@ interface ProfileEditFormProps {
 
 export default function ProfileEditForm({ user, onSave }: ProfileEditFormProps) {
   const t = useTranslations('profile.edit');
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const queryClient = useQueryClient();
+  const { mutateAsync: updateProfile, isPending: saving, error } = useUpdateProfile();
 
   const ProfileEditSchema = z.object({
     firstName: z.string().min(2, t("errors.nameMin")),
@@ -48,18 +44,12 @@ export default function ProfileEditForm({ user, onSave }: ProfileEditFormProps) 
   });
 
   const onSubmit = async (data: ProfileEditFormData) => {
-    setSaving(true);
-    setError(null);
     try {
-      await userApi.updateUser({ ...data, userId: user.id ?? '' });
-      queryClient.invalidateQueries({ queryKey: ['session'] });
-      queryClient.invalidateQueries({ queryKey: ['currentUser'] });
+      await updateProfile({ ...data, userId: user.id ?? '' });
       onSave();
-    } catch (err) {
-      console.error('Error updating profile:', err);
-      setError(err instanceof Error ? err.message : t("errors.updateError"));
-    } finally {
-      setSaving(false);
+    } catch {
+      // Error UI is driven by the mutation's `error` state; toast feedback
+      // is handled inside useUpdateProfile.
     }
   };
 
@@ -67,7 +57,7 @@ export default function ProfileEditForm({ user, onSave }: ProfileEditFormProps) 
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
       {error && (
         <div className="p-4 bg-red-100 dark:bg-red-900/30 border border-red-400 dark:border-red-700 text-red-700 dark:text-red-300 rounded-lg">
-          {error}
+          {error.message || t("errors.updateError")}
         </div>
       )}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -1,5 +1,4 @@
-import { z } from 'zod';
-import { fetcher, mutator } from './base';
+import { mutator } from './base';
 import { apiModel, authModel } from '../models';
 
 // ============================================================================
@@ -44,9 +43,3 @@ export async function resetPassword(token: string, password: string): Promise<ap
         arg: { token, password },
     });
 }
-
-/**
- * [GET] /api/v1/auth/status - Returns if the user is authenticated.
- * NOTE: This endpoint is not yet implemented on the backend.
- * */
-export const getStatus = () => fetcher('/api/v1/auth/status', z.boolean());

--- a/lib/hooks/__tests__/userHooks.test.ts
+++ b/lib/hooks/__tests__/userHooks.test.ts
@@ -1,0 +1,78 @@
+import React, { type ReactNode } from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { user } from '../../api';
+import { useUpdateProfile } from '../userHooks';
+import { useApiError } from '../useApiError';
+
+jest.mock('../../api', () => ({
+    user: {
+        updateUser: jest.fn(),
+    },
+}));
+
+jest.mock('../useApiError', () => ({
+    useApiError: jest.fn(),
+}));
+
+const updateUserMock = user.updateUser as jest.Mock;
+const useApiErrorMock = useApiError as jest.Mock;
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+            mutations: { retry: false },
+        },
+    });
+
+    const wrapper = ({ children }: { children: ReactNode }) =>
+        React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+    return { queryClient, wrapper };
+};
+
+describe('useUpdateProfile', () => {
+    const handleError = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        useApiErrorMock.mockReturnValue({ handleError });
+    });
+
+    it('invalidates the session and currentUser queries on success', async () => {
+        const { queryClient, wrapper } = createWrapper();
+        const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+        updateUserMock.mockResolvedValueOnce({ code: 0, message: 'Profile updated successfully' });
+
+        const { result } = renderHook(() => useUpdateProfile(), { wrapper });
+
+        await act(async () => {
+            await result.current.mutateAsync({ userId: 'u1', firstName: 'Ada' });
+        });
+
+        expect(updateUserMock.mock.calls[0][0]).toEqual({ userId: 'u1', firstName: 'Ada' });
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['session'] });
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['currentUser'] });
+        expect(handleError).not.toHaveBeenCalled();
+    });
+
+    it('surfaces the error via useApiError and skips invalidation on failure', async () => {
+        const { queryClient, wrapper } = createWrapper();
+        const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+        const error = new Error('Profile update failed');
+        updateUserMock.mockRejectedValueOnce(error);
+
+        const { result } = renderHook(() => useUpdateProfile(), { wrapper });
+
+        await act(async () => {
+            await result.current.mutateAsync({ userId: 'u1', firstName: 'Ada' }).catch(() => undefined);
+        });
+
+        await waitFor(() => {
+            expect(handleError).toHaveBeenCalledWith(error);
+        });
+        expect(invalidateSpy).not.toHaveBeenCalled();
+    });
+});

--- a/lib/hooks/userHooks.ts
+++ b/lib/hooks/userHooks.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { user } from '../api';
+import { useApiError } from './useApiError';
+
+/** Hook to update the authenticated user's profile. */
+export const useUpdateProfile = () => {
+    const queryClient = useQueryClient();
+    const { handleError } = useApiError();
+
+    return useMutation({
+        mutationFn: user.updateUser,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['session'] });
+            queryClient.invalidateQueries({ queryKey: ['currentUser'] });
+        },
+        onError: (error) => {
+            console.error('Profile update failed:', error);
+            handleError(error);
+        },
+    });
+};


### PR DESCRIPTION
## Summary
- Remove the unused `getStatus` API function for `/auth/status` — no backend endpoint, no consumers (#103).
- Add `useUpdateProfile` mutation hook and switch `ProfileEditForm` to use it instead of calling the API and invalidating queries directly (#101).

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes on changed files
- [x] `useUpdateProfile` unit tests added (success + error paths)
- [x] Existing `authHooks`/`user` API test suites still pass
- [ ] Manual check: edit profile fields in the UI, confirm success updates the header/session data and error still surfaces inline

Closes #101 
Closes #103 
